### PR TITLE
Fix cursorline - virtual_text hl_mode into combine

### DIFF
--- a/lua/oil-git.lua
+++ b/lua/oil-git.lua
@@ -156,6 +156,7 @@ local function apply_git_highlights()
 					vim.api.nvim_buf_set_extmark(bufnr, ns_id, i - 1, 0, {
 						virt_text = { { " " .. symbol, hl_group } },
 						virt_text_pos = "eol",
+						hl_mode = "combine",
 					})
 				end
 			end

--- a/lua/oil-git.lua
+++ b/lua/oil-git.lua
@@ -230,7 +230,7 @@ local function initialize()
 	if initialized then
 		return
 	end
-	
+
 	setup_highlights()
 	setup_autocmds()
 	initialized = true


### PR DESCRIPTION
When using oil-git.nvim, the git status symbols (e.g., ~) added via virtual text do not respect the cursorline background highlight. This happens because the default hl_mode for nvim_buf_set_extmark is "replace", which overrides the background set by CursorLine.

This PR sets hl_mode = "combine" when placing the extmark, allowing the git symbol highlight to blend with the cursorline background, resulting in consistent visual behavior when navigating files.

![8pHo1kn](https://github.com/user-attachments/assets/abd7d302-d146-4a5f-9976-cf2e67ce660c)

![2025-07-03 at 20 47 20@2x](https://github.com/user-attachments/assets/be93bf0b-feb5-45c6-b8fd-9a93ccb3f48f)
