### PR TITLE
Add option to ignore GitSigns to get rid of periodic cursor flickering

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ require("oil-git").setup({
 
 ## Git Status Display
 
-| Status | Symbol | Color | Description |
-|--------|---------|-------|-------------|
-| **+** | Added | Green | Staged new file |
-| **~** | Modified | Yellow | Modified file (staged or unstaged) |
-| **-** | Deleted | Red | Deleted file |
-| **→** | Renamed | Purple | Renamed file |
-| **?** | Untracked | Blue | New untracked file |
-| **!** | Ignored | Gray | Ignored file |
+| Status | Symbol    | Color  | Description                        |
+|--------|-----------|--------|------------------------------------|
+| **+**  | Added     | Green  | Staged new file                    |
+| **~**  | Modified  | Yellow | Modified file (staged or unstaged) |
+| **-**  | Deleted   | Red    | Deleted file                       |
+| **→**  | Renamed   | Purple | Renamed file                       |
+| **?**  | Untracked | Blue   | New untracked file                 |
+| **!**  | Ignored   | Gray   | Ignored file                       |
 
 ## Auto-refresh Triggers
 
@@ -113,6 +113,8 @@ The plugin automatically refreshes git status when:
 ## Commands
 
 - `:lua require("oil-git").refresh()` - Manually refresh git status
+- `:OilGitDisable` - Disable Oil Git e.g. when it is too laggy
+- `:OilGitEnable` - Enable Oil Git when it is disabled
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Git status integration for [oil.nvim](https://github.com/stevearc/oil.nvim) that
   opts = {
     highlights = {
       OilGitModified = { fg = "#ff0000" }, -- Custom colors
-    }
+    },
+    ignore_git_signs = true, -- Gets rid of annoying cursor flickering by disabling listening for updates from GitSigns
   }
 }
 ```
@@ -82,7 +83,8 @@ require("oil-git").setup({
     OilGitRenamed = { fg = "#cba6f7" },   -- purple
     OilGitUntracked = { fg = "#89b4fa" }, -- blue
     OilGitIgnored = { fg = "#6c7086" },   -- gray
-  }
+  },
+  ignore_git_signs = false,
 })
 ```
 

--- a/lua/oil-git.lua
+++ b/lua/oil-git.lua
@@ -229,6 +229,16 @@ local function setup_autocmds()
 	})
 end
 
+local function setup_commands()
+	vim.api.nvim_create_user_command("OilGitDisable", function()
+		vim.api.nvim_del_augroup_by_name("OilGitStatus")
+	end, { desc = "Disable OilGit" })
+
+	vim.api.nvim_create_user_command("OilGitEnable", function()
+		setup_autocmds()
+	end, { desc = "Enable OilGit" })
+end
+
 -- Track if plugin has been initialized
 local initialized = false
 
@@ -239,6 +249,7 @@ local function initialize()
 	
 	setup_highlights()
 	setup_autocmds()
+	setup_commands()
 	initialized = true
 end
 

--- a/lua/oil-git.lua
+++ b/lua/oil-git.lua
@@ -9,6 +9,8 @@ local default_highlights = {
 	OilGitIgnored = { fg = "#6c7086" },
 }
 
+local ignore_git_signs = false
+
 local function setup_highlights()
 	-- Only set highlight if it doesn't already exist (respects colorscheme)
 	for name, opts in pairs(default_highlights) do
@@ -212,9 +214,13 @@ local function setup_autocmds()
 	})
 
 	-- Also catch common git-related user events
+	local user_events = { "FugitiveChanged", "LazyGitClosed" }
+	if not ignore_git_signs then
+		table.insert(user_events, "GitSignsUpdate")
+	end
 	vim.api.nvim_create_autocmd("User", {
 		group = group,
-		pattern = { "FugitiveChanged", "GitSignsUpdate", "LazyGitClosed" },
+		pattern = user_events,
 		callback = function()
 			if vim.bo.filetype == "oil" then
 				vim.schedule(apply_git_highlights)
@@ -243,6 +249,9 @@ function M.setup(opts)
 	if opts.highlights then
 		default_highlights = vim.tbl_extend("force", default_highlights, opts.highlights)
 	end
+
+	-- This options ignores the update on the "GitSignsUpdate" user event to get rid of the annoying cursor flickering
+	ignore_git_signs = opts.ignore_git_signs or false
 
 	initialize()
 end


### PR DESCRIPTION
The issue causing the cursor flickering is the `GitSignsUpdate` user event that triggers every so often and causes the `apply_git_highlights` function to be called.

Introduces the `ignore_git_signs` option for users who prefer having GitSigns checked. Users who don't like the cursor flickering and don't mind GitSigns not being checked can turn this option to `true`.

This PR does not resolve the cursor flickering all together, but gets rid of the periodic cursor flickering, which is good enough for me.

Should resolve #4, when the new option is enabled.