### PR TITLE
Add configurable prefix for git symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ require("oil-git").setup({
     OilGitRenamed = { fg = "#cba6f7" },   -- purple
     OilGitUntracked = { fg = "#89b4fa" }, -- blue
     OilGitIgnored = { fg = "#6c7086" },   -- gray
-  }
+  },
+  prefix = " " -- Prefix before git symbols (default: " ")
 })
 ```
 

--- a/lua/oil-git.lua
+++ b/lua/oil-git.lua
@@ -154,9 +154,11 @@ local function apply_git_highlights()
 					-- Add symbol as virtual text at the end of the line
 					local ns_id = vim.api.nvim_create_namespace("oil_git_status")
 					local symbol_text = M.prefix .. symbol
-					vim.api.nvim_buf_set_extmark(bufnr, ns_id, i - 1, 0, {
+					-- Position at the actual end of the line content instead of EOL
+					local line_len = #line
+					vim.api.nvim_buf_set_extmark(bufnr, ns_id, i - 1, line_len, {
 						virt_text = { { symbol_text, hl_group } },
-						virt_text_pos = "eol",
+						virt_text_pos = "inline",
 					})
 				end
 			end

--- a/lua/oil-git.lua
+++ b/lua/oil-git.lua
@@ -153,8 +153,9 @@ local function apply_git_highlights()
 
 					-- Add symbol as virtual text at the end of the line
 					local ns_id = vim.api.nvim_create_namespace("oil_git_status")
+					local symbol_text = M.prefix .. symbol
 					vim.api.nvim_buf_set_extmark(bufnr, ns_id, i - 1, 0, {
-						virt_text = { { " " .. symbol, hl_group } },
+						virt_text = { { symbol_text, hl_group } },
 						virt_text_pos = "eol",
 					})
 				end
@@ -226,6 +227,9 @@ end
 -- Track if plugin has been initialized
 local initialized = false
 
+-- Default prefix setting (can be overridden in setup)
+M.prefix = " "
+
 local function initialize()
 	if initialized then
 		return
@@ -243,6 +247,9 @@ function M.setup(opts)
 	if opts.highlights then
 		default_highlights = vim.tbl_extend("force", default_highlights, opts.highlights)
 	end
+
+	-- Store prefix option
+	M.prefix = opts.prefix ~= nil and opts.prefix or " " -- Default to single space
 
 	initialize()
 end


### PR DESCRIPTION
Adds a configurable prefix option for git status symbols. Default is a single space but can be customized or removed for tighter spacing.